### PR TITLE
feat: update the color theme of url icon

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -90,7 +90,7 @@ const HomePage = () => {
         <div className="w-full max-w-md">
           <div className="bg-white/10 backdrop-blur-xl rounded-3xl p-8 shadow-2xl border border-white/20">
             <div className="text-center mb-8">
-              <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-blue-500 to-purple-600 rounded-2xl mb-4 shadow-lg">
+              <div className="inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-blue-600 to-gray-600 rounded-2xl mb-4 shadow-lg">
                 <svg
                   className="w-8 h-8 text-white"
                   fill="none"


### PR DESCRIPTION
Added a dark blue plus gray neutral color theme to the url icon in the shortening form in the home page.
Closes #11 